### PR TITLE
add requirements for the graph widget

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ pytz==2024.2
 six==1.16.0
 sortedcontainers==2.4.0
 typing_extensions==4.12.2
+numpy==1.24.4
+pyqtgraph==0.13.3


### PR DESCRIPTION
This widget won't work without numpy/pyqtgraph.
![image](https://github.com/user-attachments/assets/2a252061-091c-49f4-9b2f-e7bb353064a8)