### PR TITLE
add new columns to tree with live updates

### DIFF
--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,5 +1,4 @@
 from PyQt5.QtCore import Qt
-from uaclient.mainwindow import Window
 
 
 def get_attr_value(text, client):
@@ -46,23 +45,6 @@ def test_connect(server, url, client):
         client.uaclient.settings.value("current_node")[url]
         == current_node.nodeid.to_string()
     )
-
-
-def test_disconnect(qtbot, url, server):
-    client = Window()
-    qtbot.addWidget = client
-    client.ui.addrComboBox.setCurrentText(url)
-    client.connect()
-    current_node = client.tree_ui.get_current_node()
-    client.disconnect()
-
-    assert not client.uaclient._connected
-    assert (
-        client.uaclient.settings.value("current_node")[url]
-        == current_node.nodeid.to_string()
-    )
-    assert len(client.tree_ui.model._fetched) == 0
-    assert len(client.event_ui._subscribed_nodes) == 0
 
 
 def test_load_current_node(client, server, url):

--- a/tests/unit/test_data_changed.py
+++ b/tests/unit/test_data_changed.py
@@ -1,0 +1,49 @@
+import pytest
+from uaclient.mainwindow import DataChangeSubscriptionManager
+from unittest.mock import Mock
+
+
+@pytest.fixture
+def server_node(server):
+    yield server.nodes.server
+
+
+@pytest.fixture
+def window(server_node):
+    window = Mock()
+    window.get_current_node.return_value = server_node
+    yield window
+
+
+@pytest.fixture
+def uaclient():
+    yield Mock()
+
+
+def test_subscribe_data_changed(window, server_node, uaclient):
+    data_change_manager = DataChangeSubscriptionManager(window, uaclient)
+    data_change_manager._subscribe()
+
+    # only one subscription per node is allowed, so this should not be added to _subscribed_nodes
+    data_change_manager._subscribe()
+
+    assert len(data_change_manager._subscribed_nodes) == 1
+    assert data_change_manager._subscribed_nodes[0] == server_node
+
+
+def test_unsubscribe_data_changed(window, server_node, uaclient):
+    data_change_manager = DataChangeSubscriptionManager(window, uaclient)
+    data_change_manager._subscribe(server_node)
+    assert len(data_change_manager._subscribed_nodes) == 1
+
+    data_change_manager._unsubscribe(server_node)
+    data_change_manager._unsubscribe(server_node)
+    assert len(data_change_manager._subscribed_nodes) == 0
+
+
+def test_clear(window, server_node, uaclient):
+    data_change_manager = DataChangeSubscriptionManager(window, uaclient)
+    data_change_manager._subscribe(server_node)
+
+    data_change_manager.clear()
+    assert len(data_change_manager._subscribed_nodes) == 0

--- a/tests/unit/test_tree.py
+++ b/tests/unit/test_tree.py
@@ -1,0 +1,51 @@
+from asyncua.sync import Server
+from PyQt5.QtTest import QSignalSpy
+import pytest
+from asyncua import ua
+
+
+@pytest.fixture
+def server(url):
+    server = Server()
+    namepace = server.register_namespace("custom_namespace")
+    objects = server.nodes.root
+    objects.add_variable(namepace, "float_variable", 1.0)
+    server.set_endpoint(url)
+    server.start()
+    yield server
+    server.stop()
+
+
+def test_extra_columns(client, server):
+    tree_model = client.tree_ui.model
+    root = tree_model.itemFromIndex(tree_model.index(0, 0))
+    tree_model.subscription_handlers[root.index()].subscribe_thread.wait()
+    id = root.child(3, 2).text()
+    signal = client.node_signal_dict[id].signal
+    spy = QSignalSpy(signal)
+    assert spy.wait()
+    assert root.child(3, 4).text() == "float_variable"
+    assert root.child(3, 5).text() == "Double"
+    assert root.child(3, 3).text() == "1.0"
+
+    node = server.get_node(id)
+
+    node.write_attribute(ua.AttributeIds.Value, ua.DataValue(2.0))
+    assert node in client.tree_ui.model.data_change_manager._subscribed_nodes
+    assert spy.wait()
+    assert root.child(3, 3).text() == "2.0"
+
+
+def test_unsub_extra_columns(client, server):
+    tree_model = client.tree_ui.model
+    root = tree_model.itemFromIndex(tree_model.index(0, 0))
+    tree_model.subscription_handlers[root.index()].subscribe_thread.wait()
+    id = root.child(3, 2).text()
+    signal = client.node_signal_dict[id].signal
+    node = server.get_node(id)
+    spy = QSignalSpy(signal)
+    spy.wait()
+    client.ui.treeView.setExpanded(root.index(), False)
+    tree_model.subscription_handlers[root.index()].unsubscribe_thread.wait()
+
+    assert node not in tree_model.data_change_manager._subscribed_nodes

--- a/tests/unit/test_uaclient.py
+++ b/tests/unit/test_uaclient.py
@@ -2,6 +2,7 @@ import pytest
 
 from uaclient.mainwindow import EventHandler
 from uaclient.uaclient import UaClient
+from uaclient.tree.data_change_handler import DataChangeHandler
 from unittest.mock import Mock
 from asyncua.sync import Subscription, Client
 
@@ -22,6 +23,18 @@ def uaclient(url):
     uaclient.connect(url)
     yield uaclient
     uaclient.disconnect()
+
+
+def test_subscribe_datachange(uaclient, server):
+    node_signal_dict = {}
+    handler = DataChangeHandler(node_signal_dict)
+    namepace = server.register_namespace("custom_namespace")
+    objects = server.nodes.objects
+    float_variable = objects.add_variable(namepace, "float_variable", 1.0)
+    assert not uaclient._datachange_sub
+    handler = uaclient.subscribe_datachange(float_variable, handler)
+    assert isinstance(uaclient._datachange_sub, Subscription)
+    assert handler == uaclient._subs_dc[float_variable.nodeid]
 
 
 def test_subscribe_events(uaclient, server):

--- a/uaclient/tree/data_change_handler.py
+++ b/uaclient/tree/data_change_handler.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+
+from PyQt5.QtCore import pyqtSignal, QObject
+
+
+class DataChangeHandler(QObject):
+
+    def __init__(self, node_signal_dict):
+        super().__init__()
+        self.node_signal_dict = node_signal_dict
+
+    data_change_fired = pyqtSignal(object, str, str)
+
+    def datachange_notification(self, node, val, data):
+        if data.monitored_item.Value.SourceTimestamp:
+            dato = data.monitored_item.Value.SourceTimestamp.isoformat()
+        elif data.monitored_item.Value.ServerTimestamp:
+            dato = data.monitored_item.Value.ServerTimestamp.isoformat()
+        else:
+            dato = datetime.now().isoformat()
+        self.node_signal_dict[str(node)].signal.emit(node, val, dato)

--- a/uaclient/tree/data_change_subscription_manager.py
+++ b/uaclient/tree/data_change_subscription_manager.py
@@ -1,0 +1,63 @@
+import logging
+
+from asyncua import ua
+from asyncua.sync import SyncNode
+
+from uawidgets.utils import trycatchslot
+
+logger = logging.getLogger(__name__)
+
+
+class DataChangeSubscriptionManager:
+
+    def __init__(self, window, uaclient):
+        self.window = window
+        self.uaclient = uaclient
+        self._subscribed_nodes = []
+
+    def clear(self):
+        self._subscribed_nodes = []
+
+    def show_error(self, *args):
+        self.window.show_error(*args)
+
+    @trycatchslot
+    def _subscribe(self, node=None):
+        if not isinstance(node, SyncNode):
+            node = self.window.get_current_node()
+            if node is None:
+                return
+        if node in self._subscribed_nodes:
+            return
+        try:
+            self.uaclient.subscribe_datachange(node, self.window._subhandler)
+
+        except Exception as ex:
+            if type(ex) is ua.uaerrors.BadAttributeIdInvalid:
+                return
+            return ex
+
+        self._subscribed_nodes.append(node)
+
+    @trycatchslot
+    def _unsubscribe(self, node):
+        if node is None:
+            node = self.window.get_current_node()
+        try:
+            self._subscribed_nodes.remove(node)
+            self.uaclient.unsubscribe_datachange(node)
+        except Exception as ex:
+            if type(ex) is ValueError:
+                return
+            logger.error(ex)
+
+    def _update_subscription_model(self, node, value, timestamp):
+        i = 0
+        while self.model.item(i):
+            item = self.model.item(i)
+            if item.data() == node:
+                it = self.model.item(i, 1)
+                it.setText(value)
+                it_ts = self.model.item(i, 2)
+                it_ts.setText(timestamp)
+            i += 1

--- a/uaclient/tree/description_datatype_worker.py
+++ b/uaclient/tree/description_datatype_worker.py
@@ -1,0 +1,21 @@
+from PyQt5.QtCore import QRunnable
+
+from asyncua.common.ua_utils import data_type_to_string
+
+from asyncua import ua
+
+
+class DescriptionDatatypeWorker(QRunnable):
+    def __init__(self, node, description, data_type):
+        super().__init__()
+        self.node = node
+        self.description = description
+        self.data_type = data_type
+
+    def run(self):
+        attrs = self.node.read_attributes(
+            [ua.AttributeIds.Description, ua.AttributeIds.DataType]
+        )
+        self.description.setText(attrs[0].Value.Value.Text)
+        if attrs[1].Value.Value:
+            self.data_type.setText(data_type_to_string(attrs[1].Value.Value))

--- a/uaclient/tree/node_subscription_signal.py
+++ b/uaclient/tree/node_subscription_signal.py
@@ -1,0 +1,5 @@
+from PyQt5.QtCore import pyqtSignal, QObject
+
+
+class NodeSubscriptionSignal(QObject):
+    signal = pyqtSignal(object, object, str)

--- a/uaclient/tree/node_value_item.py
+++ b/uaclient/tree/node_value_item.py
@@ -1,0 +1,9 @@
+from PyQt5.QtGui import QStandardItem
+
+
+class NodeValueItem(QStandardItem):
+    def __init__(self, value):
+        super(NodeValueItem, self).__init__(value)
+
+    def update_value(self, node, val, data):
+        self.setText(str(val))

--- a/uaclient/tree/subscribe_worker.py
+++ b/uaclient/tree/subscribe_worker.py
@@ -1,0 +1,39 @@
+import logging
+from PyQt5.QtCore import QThread
+
+logger = logging.getLogger(__name__)
+
+
+class SubscribeWorker(QThread):
+    def __init__(self, idx, model, subscription_handler):
+        super().__init__()
+        self.idx = idx
+        self.model = model
+        self.uaclient = model.uaclient
+        self.data_change_manager = model.data_change_manager
+        self.subscription_handler = subscription_handler
+        self.last_unsubscribed = subscription_handler.last_unsubscribed
+
+    def run(self):
+        self.subscription_handler.expanded_lock.lock()
+        self.subscription_handler.is_expanded = True
+        self.subscription_handler.expanded_lock.unlock()
+
+        self.subscription_handler.thread_running_lock.lock()
+        idx = self.idx
+        item = self.model.itemFromIndex(idx)
+        i = 0
+        while True:
+            child = item.child(i)
+            if child is None or i == self.last_unsubscribed:
+                break
+            index = item.child(i).index()
+            childNodeId = self.model.data(index.sibling(index.row(), 2))
+            childNode = self.uaclient.client.get_node(childNodeId)
+            res = self.data_change_manager._subscribe(childNode)
+            if res:
+                logger.error(res)
+                break
+            i = i + 1
+        self.last_unsubscribed = -1
+        self.subscription_handler.thread_running_lock.unlock()

--- a/uaclient/tree/subscription_handler.py
+++ b/uaclient/tree/subscription_handler.py
@@ -1,0 +1,17 @@
+from PyQt5.QtCore import QObject, QMutex
+from uaclient.tree.subscribe_worker import SubscribeWorker
+from uaclient.tree.unsubscribe_worker import UnsubscribeWorker
+
+
+class SubscriptionHandler(QObject):
+
+    def __init__(self, model, idx):
+        super().__init__()
+        self.model = model
+        self.idx = idx
+        self.is_expanded = False
+        self.last_unsubscribed = -1
+        self.thread_running_lock = QMutex()
+        self.expanded_lock = QMutex()
+        self.subscribe_thread = SubscribeWorker(idx, model, self)
+        self.unsubscribe_thread = UnsubscribeWorker(idx, model, self)

--- a/uaclient/tree/tree_model.py
+++ b/uaclient/tree/tree_model.py
@@ -1,0 +1,136 @@
+from PyQt5.QtCore import (
+    pyqtSignal,
+    Qt,
+    QThreadPool,
+)
+from PyQt5.QtGui import QStandardItem, QIcon
+
+from asyncua import ua
+from asyncua.sync import new_node
+
+from uawidgets.tree_widget import TreeViewModel
+
+from uaclient.tree.node_value_item import NodeValueItem
+from uaclient.tree.subscription_handler import SubscriptionHandler
+from uaclient.tree.description_datatype_worker import DescriptionDatatypeWorker
+from uaclient.tree.node_subscription_signal import NodeSubscriptionSignal
+
+
+class TreeModel(TreeViewModel):
+
+    description_datatype_added = pyqtSignal(object, object, object)
+
+    def __init__(self, uaclient, node_signal_dict, data_change_manager):
+        super().__init__()
+        self.uaclient = uaclient
+        self.test_item = 0
+        self.node_signal_dict = node_signal_dict
+        self.threadpool = QThreadPool()
+        self.data_change_manager = data_change_manager
+        self.subscription_handlers = {}
+
+    # Copied from the opcua-widgets package and edited to fit this project
+    # location: https://github.com/FreeOpcUa/opcua-widgets/blob/0bbfca198029a423fb6dd45fde0f60d7c57a5c00/uawidgets/tree_widget.py#L164
+    # Copied and edited on 12/30/2024
+    def set_root_node(self, node):
+        desc = self._get_node_desc(node, is_root=True)
+        self.add_item(desc, node=node, is_root=True)
+
+    # Copied from the opcua-widgets package and edited to fit this project
+    # location: https://github.com/FreeOpcUa/opcua-widgets/blob/0bbfca198029a423fb6dd45fde0f60d7c57a5c00/uawidgets/tree_widget.py#L168
+    # Copied and edited on 12/30/2024
+    def _get_node_desc(self, node, is_root=False):
+        attrs = node.read_attributes(
+            [
+                ua.AttributeIds.DisplayName,
+                ua.AttributeIds.BrowseName,
+                ua.AttributeIds.NodeId,
+                ua.AttributeIds.NodeClass,
+            ]
+        )
+        desc = ua.ReferenceDescription()
+        desc.DisplayName = attrs[0].Value.Value
+        desc.BrowseName = attrs[1].Value.Value
+        desc.NodeId = attrs[2].Value.Value
+        desc.NodeClass = attrs[3].Value.Value
+        if is_root:
+            desc.TypeDefinition = ua.TwoByteNodeId(ua.ObjectIds.FolderType)
+        return desc
+
+    def tree_expanded(self, idx):
+        if idx not in self.subscription_handlers:
+            self.subscription_handlers[idx] = SubscriptionHandler(self, idx)
+
+        if self.subscription_handlers[idx].subscribe_thread.isRunning():
+            return
+        self.subscription_handlers[idx].subscribe_thread.start()
+
+    def tree_collapsed(self, idx):
+        self.subscription_handlers[idx].unsubscribe_thread.start()
+
+    def update_description_and_data_type(self, node, description, data_type):
+        worker = DescriptionDatatypeWorker(node, description, data_type)
+        self.threadpool.start(worker)
+
+    # Copied from the opcua-widgets package and edited to fit this project
+    # location: https://github.com/FreeOpcUa/opcua-widgets/blob/0bbfca198029a423fb6dd45fde0f60d7c57a5c00/uawidgets/tree_widget.py#L178
+    # Copied and edited on 12/30/2024
+    def add_item(self, desc, parent=None, node=None, is_root=False):
+        dname = bname = nodeid = "No Value"
+        dtype = value = description = None
+
+        if not node:
+            node = self.uaclient.get_node(desc.NodeId)
+
+        if value == "None":
+            value = ""
+        if description == "no description":
+            description = ""
+
+        if desc.DisplayName:
+            dname = desc.DisplayName.Text
+        if desc.BrowseName:
+            bname = desc.BrowseName.to_string()
+        nodeid = desc.NodeId.to_string()
+        item = [
+            QStandardItem(dname),
+            QStandardItem(bname),
+            QStandardItem(nodeid),
+            NodeValueItem(""),
+            QStandardItem(description),
+            QStandardItem(dtype),
+        ]
+        if desc.NodeClass == ua.NodeClass.Object:
+            if desc.TypeDefinition == ua.TwoByteNodeId(ua.ObjectIds.FolderType):
+                item[0].setIcon(QIcon(":/folder.svg"))
+            else:
+                item[0].setIcon(QIcon(":/object.svg"))
+        elif desc.NodeClass == ua.NodeClass.Variable:
+            if desc.TypeDefinition == ua.TwoByteNodeId(ua.ObjectIds.PropertyType):
+                item[0].setIcon(QIcon(":/property.svg"))
+            else:
+                item[0].setIcon(QIcon(":/variable.svg"))
+        elif desc.NodeClass == ua.NodeClass.Method:
+            item[0].setIcon(QIcon(":/method.svg"))
+        elif desc.NodeClass == ua.NodeClass.ObjectType:
+            item[0].setIcon(QIcon(":/object_type.svg"))
+        elif desc.NodeClass == ua.NodeClass.VariableType:
+            item[0].setIcon(QIcon(":/variable_type.svg"))
+        elif desc.NodeClass == ua.NodeClass.DataType:
+            item[0].setIcon(QIcon(":/data_type.svg"))
+        elif desc.NodeClass == ua.NodeClass.ReferenceType:
+            item[0].setIcon(QIcon(":/reference_type.svg"))
+
+        if is_root:
+            item[0].setData(node, Qt.UserRole)
+        else:
+            parent_node = parent.data(Qt.UserRole)
+            item[0].setData(new_node(parent_node, desc.NodeId), Qt.UserRole)
+
+        self.node_signal_dict[nodeid] = NodeSubscriptionSignal()
+        self.node_signal_dict[nodeid].signal.connect(item[3].update_value)
+        self.description_datatype_added.emit(node, item[4], item[5])
+        if parent:
+            return parent.appendRow(item)
+        else:
+            return self.appendRow(item)

--- a/uaclient/tree/unsubscribe_worker.py
+++ b/uaclient/tree/unsubscribe_worker.py
@@ -1,0 +1,38 @@
+from PyQt5.QtCore import QThread
+
+
+class UnsubscribeWorker(QThread):
+    def __init__(self, idx, model, subscription_handler):
+        super().__init__()
+        self.idx = idx
+        self.model = model
+        self.uaclient = model.uaclient
+        self.data_change_manager = model.data_change_manager
+        self.node_signal_dict = model.node_signal_dict
+        self.idx = idx
+        self.subscription_handler = subscription_handler
+
+    def run(self):
+        self.subscription_handler.thread_running_lock.lock()
+        self.subscription_handler.expanded_lock.lock()
+        self.subscription_handler.is_expanded = False
+        self.subscription_handler.expanded_lock.unlock()
+        item = self.model.itemFromIndex(self.idx)
+        i = 0
+        while True:
+            self.subscription_handler.expanded_lock.lock()
+            if self.subscription_handler.is_expanded:
+                self.subscription_handler.last_unsubscribed = i
+                self.subscription_handler.expanded_lock.unlock()
+                break
+            self.subscription_handler.expanded_lock.unlock()
+            child = item.child(i)
+            if child is None:
+                break
+            index = item.child(i).index()
+            childNodeId = self.model.data(index.sibling(index.row(), 2))
+            childNode = self.uaclient.client.get_node(childNodeId)
+            if childNodeId in self.node_signal_dict:
+                self.data_change_manager._unsubscribe(childNode)
+            i = i + 1
+        self.subscription_handler.thread_running_lock.unlock()


### PR DESCRIPTION
This feature adds the columns 'Value','Description', and 'DataType' to the node tree. These columns require multithreading to load their values they need to query each node in order to find the data which is a relatively slow operation. This feature also adds live updates to the value column via a subscription. These subscriptions also show up in the attributes window, so updates can be viewed live in this window as well.