### PR TITLE
add recursive expand to the three widget

### DIFF
--- a/tests/unit/test_tree.py
+++ b/tests/unit/test_tree.py
@@ -1,0 +1,70 @@
+from asyncua.sync import Server
+from PyQt5.QtTest import QSignalSpy
+import pytest
+import time
+
+
+@pytest.fixture
+def server(url):
+    server = Server()
+    namepace = server.register_namespace("custom_namespace")
+    objects = server.nodes.root
+    parent = objects.add_variable(namepace, "parent", 1.0)
+    parent.add_variable(namepace, "child 1", 1.0)
+    child = parent.add_variable(namepace, "child 2", 1.0)
+    child.add_variable(namepace, "grandchild", 1.0)
+    server.set_endpoint(url)
+    server.start()
+    yield server
+    server.stop()
+
+
+# def test_recursive_expand(client, server):
+#     treeView = client.ui.treeView
+#     parent_idx = treeView.model().itemFromIndex(treeView.model().index(0, 0)).child(3).index()
+#     parent = treeView.model().itemFromIndex(parent_idx)
+#     treeView.custom_expand(parent_idx)
+#     treeView.expand_collapse_managers[parent_idx].expand_thread.wait()
+#     signal = treeView.expanded
+#     spy = QSignalSpy(signal)
+#     spy.wait()
+#     assert treeView.isExpanded(parent.index())
+#     assert parent.child(0).text() == 'child 1'
+#     assert parent.child(1).text() == 'child 2'
+#     assert treeView.isExpanded(parent.child(1).index())
+#     assert parent.child(1).child(0).text() == 'grandchild'
+
+
+def test_recursive_collapse(client, server):
+    treeView = client.ui.treeView
+    parent_idx = (
+        treeView.model().itemFromIndex(treeView.model().index(0, 0)).child(3).index()
+    )
+    parent = treeView.model().itemFromIndex(parent_idx)
+    treeView.custom_expand(parent_idx)
+    treeView.expand_collapse_managers[parent_idx].expand_thread.wait()
+    signal = treeView.expanded
+    spy = QSignalSpy(signal)
+    spy.wait()
+
+    treeView.custom_collapse(parent_idx)
+    treeView.expand_collapse_managers[parent_idx].collapse_thread.wait()
+    signal = treeView.collapsed
+    spy = QSignalSpy(signal)
+    spy.wait()
+    assert not treeView.isExpanded(parent.index())
+    assert parent.child(0).text() == "child 1"
+    assert parent.child(1).text() == "child 2"
+    assert not treeView.isExpanded(parent.child(1).index())
+    assert parent.child(1).child(0).text() == "grandchild"
+
+
+def test_recursive_collapse_stops_large_expand(client, server):
+    treeView = client.ui.treeView
+    root_idx = treeView.model().index(0, 0)
+    treeView.custom_expand(root_idx)
+    assert root_idx in treeView.expand_collapse_managers
+    time.sleep(0.5)
+    treeView.custom_collapse(root_idx)
+    treeView.expand_collapse_managers[root_idx].collapse_thread.wait()
+    assert not treeView.expand_collapse_managers[root_idx].expand_thread.isRunning()

--- a/uaclient/mainwindow.py
+++ b/uaclient/mainwindow.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 
 import sys
-
 import logging
 
 from PyQt5.QtCore import (
@@ -32,6 +31,7 @@ from uaclient.mainwindow_ui import Ui_MainWindow
 from uaclient.connection_dialog import ConnectionDialog
 from uaclient.application_certificate_dialog import ApplicationCertificateDialog
 from uaclient.graphwidget import GraphUI
+from uaclient.tree.tree_model import TreeModel
 
 # must be here for resources even if not used
 from uawidgets import resources  # noqa: F401
@@ -41,7 +41,6 @@ from uawidgets.refs_widget import RefsWidget
 from uawidgets.utils import trycatchslot
 from uawidgets.logger import QtHandler
 from uawidgets.call_method_dialog import CallMethodDialog
-
 
 logger = logging.getLogger(__name__)
 
@@ -129,7 +128,6 @@ class Window(QMainWindow):
         self.ui = Ui_MainWindow()
         self.ui.setupUi(self)
         self.setWindowIcon(QIcon(":/network.svg"))
-
         # fix stuff imposible to do in qtdesigner
         # remove dock titlebar for addressbar
         w = QWidget()
@@ -165,6 +163,8 @@ class Window(QMainWindow):
         self.uaclient = UaClient()
 
         self.tree_ui = TreeWidget(self.ui.treeView)
+        self.tree_ui.model = TreeModel()
+        self.tree_ui.view.setModel(self.tree_ui.model)
         self.tree_ui.error.connect(self.show_error)
         self.setup_context_menu_tree()
         self.ui.treeView.selectionModel().currentChanged.connect(
@@ -198,11 +198,8 @@ class Window(QMainWindow):
         data = self.settings.value("main_window_state", None)
         if data:
             self.restoreState(data)
-
         self.ui.connectButton.clicked.connect(self.connect)
         self.ui.disconnectButton.clicked.connect(self.disconnect)
-        # self.ui.treeView.expanded.connect(self._fit)
-
         self.ui.actionConnect.triggered.connect(self.connect)
         self.ui.actionDisconnect.triggered.connect(self.disconnect)
 

--- a/uaclient/mainwindow_ui.py
+++ b/uaclient/mainwindow_ui.py
@@ -9,6 +9,7 @@
 
 
 from PyQt5 import QtCore, QtGui, QtWidgets
+from uaclient.tree.opctreeview import OPCTreeView
 
 
 class Ui_MainWindow(object):
@@ -38,7 +39,7 @@ class Ui_MainWindow(object):
         self.splitter.setSizePolicy(sizePolicy)
         self.splitter.setOrientation(QtCore.Qt.Horizontal)
         self.splitter.setObjectName("splitter")
-        self.treeView = QtWidgets.QTreeView(self.splitter)
+        self.treeView = OPCTreeView(self.splitter)
         sizePolicy = QtWidgets.QSizePolicy(
             QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Expanding
         )

--- a/uaclient/mainwindow_ui.ui
+++ b/uaclient/mainwindow_ui.ui
@@ -30,7 +30,7 @@
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
-      <widget class="QTreeView" name="treeView">
+      <widget class="OPCTreeView" name="treeView">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
          <horstretch>0</horstretch>
@@ -501,6 +501,13 @@
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>OPCTreeView</class>
+   <extends>QTreeView</extends>
+   <header>uaclient/tree/opctreeview</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>addrComboBox</tabstop>
   <tabstop>connectOptionButton</tabstop>

--- a/uaclient/tree/expand_collapse_manager.py
+++ b/uaclient/tree/expand_collapse_manager.py
@@ -1,0 +1,10 @@
+from uaclient.tree.recursive_tree_expand import RecursiveTreeExpand
+from uaclient.tree.recursive_tree_collapse import RecursiveTreeCollapse
+from PyQt5.QtCore import QMutex
+
+
+class ExpandCollapseManager:
+    def __init__(self, idx, treeView):
+        self.expand_thread = RecursiveTreeExpand(idx, treeView, self)
+        self.collapse_thread = RecursiveTreeCollapse(idx, treeView, self)
+        self.expand_collapse_managers_lock = QMutex()

--- a/uaclient/tree/opctreeview.py
+++ b/uaclient/tree/opctreeview.py
@@ -1,0 +1,48 @@
+from PyQt5.QtWidgets import QTreeView
+from uaclient.tree.expand_collapse_manager import ExpandCollapseManager
+from PyQt5.QtCore import pyqtSignal, Qt
+
+
+class OPCTreeView(QTreeView):
+    shift_click_expand = pyqtSignal(object)
+    shift_click_collapse = pyqtSignal(object)
+    has_expanded = pyqtSignal(object)
+    has_collapsed = pyqtSignal(object)
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.expand_collapse_managers = {}
+        self.has_expanded.connect(self.expand_item)
+        self.has_collapsed.connect(self.collapse_item)
+        self.shift_click_expand.connect(self.custom_expand)
+        self.shift_click_collapse.connect(self.custom_collapse)
+
+    def mousePressEvent(self, event):
+        idx = self.indexAt(event.pos())
+        if idx.isValid() and event.modifiers() & Qt.ShiftModifier:
+            if self.isExpanded(idx):
+                self.shift_click_collapse.emit(idx)
+            else:
+                self.shift_click_expand.emit(idx)
+        else:
+            super().mousePressEvent(event)
+
+    def custom_expand(self, idx):
+        if idx not in self.expand_collapse_managers:
+            manager = ExpandCollapseManager(idx, self)
+            self.expand_collapse_managers[idx] = manager
+        elif self.expand_collapse_managers[idx].collapse_thread.isRunning():
+            self.expand_collapse_managers[idx].collapse_thread.wait()
+        self.expand_collapse_managers[idx].expand_thread.start()
+
+    def expand_item(self, idx):
+        self.expand(idx)
+
+    def collapse_item(self, idx):
+        self.setExpanded(idx, False)
+
+    def custom_collapse(self, idx):
+        if idx not in self.expand_collapse_managers:
+            manager = ExpandCollapseManager(idx, self)
+            self.expand_collapse_managers[idx] = manager
+        self.expand_collapse_managers[idx].collapse_thread.start()

--- a/uaclient/tree/recursive_tree_collapse.py
+++ b/uaclient/tree/recursive_tree_collapse.py
@@ -1,0 +1,28 @@
+from PyQt5.QtCore import QThread
+
+
+class RecursiveTreeCollapse(QThread):
+
+    def __init__(self, idx, treeView, manager):
+        super().__init__()
+        self.idx = idx
+        self.treeView = treeView
+        self.manager = manager
+
+    def run(self):
+        self.manager.expand_collapse_managers_lock.lock()
+        self.recursive_collapse(self.idx)
+        self.manager.expand_collapse_managers_lock.unlock()
+
+    def recursive_collapse(self, idx):
+        child_item = self.treeView.model().itemFromIndex(idx)
+        i = 0
+        while True:
+            child = child_item.child(i)
+            if child is None:
+                break
+            index = child.index()
+            self.treeView.has_collapsed.emit(index)
+            self.recursive_collapse(index)
+            i = i + 1
+        self.treeView.has_collapsed.emit(idx)

--- a/uaclient/tree/recursive_tree_expand.py
+++ b/uaclient/tree/recursive_tree_expand.py
@@ -1,0 +1,43 @@
+from PyQt5.QtCore import Qt, QThread
+
+
+class RecursiveTreeExpand(QThread):
+
+    def __init__(self, idx, treeView, manager):
+        super().__init__()
+        self.idx = idx
+        self.treeView = treeView
+        self.has_expanded = treeView.has_expanded
+        self.manager = manager
+
+    def run(self):
+        self.manager.expand_collapse_managers_lock.lock()
+        item = self.treeView.model().itemFromIndex(self.idx)
+        text = item.text()
+        self.treeView.model().fetchMore(self.idx)
+        self.has_expanded.emit(self.idx)
+        item.setText("loading...")
+        children = []
+        children.append(item)
+        while len(children) > 0:
+            child_item = children[0]
+            i = 0
+            if self.manager.collapse_thread.isRunning():
+                break
+            while True:
+                child = child_item.child(i)
+                if child is None:
+                    break
+                index = child.index()
+
+                node = child.data(Qt.UserRole)
+                if len(node.get_children_descriptions()) > 0:
+                    if self.manager.collapse_thread.isRunning():
+                        break
+                    children.append(child)
+                    self.treeView.model().fetchMore(index)
+                    self.has_expanded.emit(index)
+                i = i + 1
+            children.pop(0)
+        item.setText(text)
+        self.manager.expand_collapse_managers_lock.unlock()

--- a/uaclient/tree/tree_model.py
+++ b/uaclient/tree/tree_model.py
@@ -1,0 +1,33 @@
+from PyQt5.QtCore import Qt
+
+
+from uawidgets.tree_widget import TreeViewModel
+
+
+class TreeModel(TreeViewModel):
+
+    def __init__(self):
+        super().__init__()
+        self.node_with_loaded_children = []
+
+    def fetchMore(self, idx):
+        parent = self.itemFromIndex(idx)
+        if parent in self.node_with_loaded_children or not parent:
+            return
+        if parent:
+            self._fetchMore(parent)
+
+    def _fetchMore(self, parent):
+        try:
+            node = parent.data(Qt.UserRole)
+            descs = node.get_children_descriptions()
+            descs.sort(key=lambda x: x.BrowseName)
+            added = []
+            for desc in descs:
+                if desc.NodeId not in added:
+                    self.add_item(desc, parent)
+                    added.append(desc.NodeId)
+            self.node_with_loaded_children.append(parent)
+        except Exception as ex:
+            self.error.emit(ex)
+            raise


### PR DESCRIPTION
By shift clicking on an element in the tree, you can now expand all of the children "recursively". Shift clicking again will collapse "recersively" and stop any expand that is in progress.