### PR TITLE
flake8: extend defaults instead of replacing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,10 +1,10 @@
 [flake8]
-ignore =
+extend-ignore =
     # let black handle this
     E501,
     # http://hexbyteinc.com/ambv-black/#line-breaks--binary-operators
     W503
-exclude =
+extend-exclude =
     # No need to traverse our git directory
     .git,
     .mypy_cache,


### PR DESCRIPTION
Use `extend-ignore` and `extend-exclude` instead of `ignore` and `exclude`, as the latter replaces defaults.