### PR TITLE
tree_ui: add OpcTreeItem

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest==8.3.3
 pytest-qt==4.4.0
+pytest-asyncio==0.24.0
 pytest-cov==5.0.0
 black==24.8.0
 flake8==7.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sortedcontainers==2.4.0
 typing_extensions==4.12.2
 numpy==1.24.4
 pyqtgraph==0.13.3
+qasync==0.27.1

--- a/run-tests
+++ b/run-tests
@@ -43,5 +43,5 @@ if [ "$run_static" = true ]; then
 fi
 
 if [ "$run_unit" = true ]; then
-	python3 -m pytest --cov=uaclient
+	python3 -m pytest --cov=uaclient --cov-report term --cov-report html
 fi

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
 import pytest
-from asyncua.sync import Server
+import asyncio
+
+from asyncua import Server
+from asyncua.sync import Server as SyncServer
+
 from uaclient.mainwindow import Window
 
 
@@ -8,9 +12,19 @@ def url():
     yield "opc.tcp://localhost:48401/freeopcua/server/"
 
 
+@pytest.fixture
+async def async_server(url):
+    server = Server()
+    await server.init()
+    server.set_endpoint(url)
+    await server.start()
+    yield server
+    await server.stop()
+
+
 @pytest.fixture(scope="module")
 def server(url):
-    server = Server()
+    server = SyncServer()
     server.set_endpoint(url)
     server.start()
     yield server
@@ -18,10 +32,35 @@ def server(url):
 
 
 @pytest.fixture
-def client(qtbot, url, server):
+def client(qtbot, url):
     client = Window()
     qtbot.addWidget = client
     client.ui.addrComboBox.setCurrentText(url)
     client.connect()
     yield client
     client.disconnect()
+
+
+@pytest.fixture
+def wait_for_signal():
+    async def _signal_waiter(signal, *, timeout=1, check_params_callback=None):
+        signal_received = asyncio.Event()
+        calls = []
+
+        def _quit_loop(*args):
+            if check_params_callback is None or check_params_callback(*args):
+                calls.append(args)
+                signal_received.set()
+
+        signal.connect(_quit_loop)
+
+        try:
+            await asyncio.wait_for(signal_received.wait(), timeout)
+        except (TimeoutError, asyncio.TimeoutError):
+            pytest.fail(
+                f"Timed out waiting to receive {signal.signal.lstrip('2')} signal"
+            )
+
+        return calls
+
+    return _signal_waiter

--- a/tests/unit/tree_ui/test_opc_tree_item.py
+++ b/tests/unit/tree_ui/test_opc_tree_item.py
@@ -1,0 +1,418 @@
+import pytest
+from unittest.mock import ANY, create_autospec
+
+from PyQt5.QtCore import QAbstractItemModel, QPersistentModelIndex, QModelIndex
+from PyQt5.QtGui import QIcon
+
+from asyncua import ua
+
+from uaclient.tree_ui import OpcTreeItem
+
+
+@pytest.fixture
+def mock_model():
+    yield create_autospec(QAbstractItemModel)
+
+
+def opc_method(parent, value):
+    return value * 2
+
+
+async def test_column_count_1(mock_model, async_server):
+    item = OpcTreeItem(
+        mock_model,
+        async_server.nodes.objects,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName],
+    )
+    assert item.column_count() == 1
+
+
+async def test_column_count_2(mock_model, async_server):
+    item = OpcTreeItem(
+        mock_model,
+        async_server.nodes.objects,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName, ua.AttributeIds.Description],
+    )
+    assert item.column_count() == 2
+
+
+async def test_column_count_browse_name(mock_model, async_server):
+    item = OpcTreeItem(
+        mock_model,
+        async_server.nodes.objects,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName, ua.AttributeIds.BrowseName],
+    )
+    assert item.column_count() == 2
+
+
+async def test_column_count_node_class(mock_model, async_server):
+    item = OpcTreeItem(
+        mock_model,
+        async_server.nodes.objects,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName, ua.AttributeIds.NodeClass],
+    )
+    assert item.column_count() == 2
+
+
+async def test_child_count(mock_model, async_server):
+    item = OpcTreeItem(
+        mock_model,
+        async_server.nodes.objects,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName],
+    )
+    assert item.child_count() == 0
+
+
+async def test_row_without_parent(mock_model, async_server):
+    item = OpcTreeItem(
+        mock_model,
+        async_server.nodes.objects,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName],
+    )
+    assert item.row() == 0
+
+
+async def test_row_with_parent(qtbot, mock_model, async_server):
+    mock_model.index.return_value = QModelIndex()
+
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_object(index, "TestObject")
+    await node.add_variable(index, "TestVariable", 42)
+
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+    await item.refresh_children()
+
+    assert item.child_count() == 1
+    assert item.child(0).row() == 0
+
+
+async def test_row_multiple_children(qtbot, mock_model, async_server):
+    mock_model.index.return_value = QModelIndex()
+
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_object(index, "TestObject")
+    await node.add_variable(index, "TestVariable1", 42)
+    await node.add_variable(index, "TestVariable2", 43)
+
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+    await item.refresh_children()
+
+    assert item.child_count() == 2
+    assert item.child(1).row() == 1
+
+
+async def test_data(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_variable(index, "TestVariable", 42)
+    item = OpcTreeItem(
+        mock_model,
+        node,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName, ua.AttributeIds.Value],
+    )
+    await item._refresh_data()
+
+    assert item.data(0) == "TestVariable"
+    assert item.data(1) == 42
+
+
+async def test_data_reversed(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_variable(index, "TestVariable", 42)
+    item = OpcTreeItem(
+        mock_model,
+        node,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.Value, ua.AttributeIds.DisplayName],
+    )
+    await item._refresh_data()
+
+    assert item.data(0) == 42
+    assert item.data(1) == "TestVariable"
+
+
+async def _setup_child_tests(mock_model, async_server):
+    mock_model.index.return_value = QModelIndex()
+
+    index = await async_server.register_namespace("test")
+    node1 = await async_server.nodes.objects.add_object(index, "TestObject1")
+    node2 = await async_server.nodes.objects.add_object(index, "TestObject2")
+
+    root_item = OpcTreeItem(
+        mock_model,
+        async_server.nodes.objects,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName],
+    )
+
+    item1 = OpcTreeItem(
+        mock_model,
+        node1,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName],
+    )
+
+    item2 = OpcTreeItem(
+        mock_model,
+        node2,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.DisplayName],
+    )
+
+    return root_item, item1, item2
+
+
+async def test_add_child(mock_model, async_server):
+    root_item, item1, item2 = await _setup_child_tests(mock_model, async_server)
+
+    await root_item.add_child(item1)
+    assert item1.parent() == root_item
+    assert root_item.child_count() == 1
+    assert root_item.child(0) == item1
+
+    await root_item.add_child(item2)
+    assert item2.parent() == root_item
+    assert root_item.child_count() == 2
+
+    # Assert that the children are sorted
+    assert root_item.child(0) == item1
+    assert root_item.child(1) == item2
+
+
+async def test_add_child_reversed(mock_model, async_server):
+    root_item, item1, item2 = await _setup_child_tests(mock_model, async_server)
+
+    await root_item.add_child(item2)
+    assert item2.parent() == root_item
+    assert root_item.child_count() == 1
+    assert root_item.child(0) == item2
+
+    await root_item.add_child(item1)
+    assert item1.parent() == root_item
+    assert root_item.child_count() == 2
+
+    # Assert that the children are still sorted
+    assert root_item.child(0) == item1
+    assert root_item.child(1) == item2
+
+
+async def test_refresh_children(qtbot, mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_object(index, "TestObject")
+    child = await node.add_variable(index, "TestVariable", 42)
+
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    mock_model.index.return_value = QModelIndex()
+
+    assert not item.children_fetched()
+
+    with qtbot.waitSignal(item.item_added, timeout=0) as blocker:
+        await item.refresh_children()
+
+    assert blocker.args[0].node == child
+    assert item.child_count() == 1
+    assert item.children_fetched()
+
+    mock_model.beginInsertRows.assert_called_with(ANY, 0, 0)
+    mock_model.endInsertRows.assert_called_with()
+
+
+async def test_clear_children(qtbot, mock_model, async_server):
+    mock_model.index.return_value = QModelIndex()
+
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_object(index, "TestObject")
+    child = await node.add_variable(index, "TestVariable", 42)
+
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+    await item.refresh_children()
+
+    assert item.children_fetched()
+    with qtbot.waitSignal(item.item_removed, timeout=0) as blocker:
+        item.clear_children()
+
+    assert blocker.args[0].node == child
+    assert item.child_count() == 0
+    assert not item.children_fetched()
+
+    mock_model.beginRemoveRows.assert_called_with(ANY, 0, 0)
+    mock_model.endRemoveRows.assert_called_with()
+
+
+async def test_set_data(qtbot, mock_model, async_server):
+    mock_model.index.return_value = QModelIndex()
+
+    item = OpcTreeItem(
+        mock_model,
+        async_server.nodes.objects,
+        QPersistentModelIndex(),
+        [ua.AttributeIds.Value],
+    )
+
+    with qtbot.waitSignal(item.data_changed, timeout=0):
+        item.set_data(ua.AttributeIds.Value, ua.DataValue(42))
+
+
+async def test_icon_without_data(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_variable(index, "TestVariable", 42)
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+
+    assert item.icon() is None
+
+
+async def test_icon_folder(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_folder(index, "TestFolder")
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/folder.svg").pixmap(20, 20).toImage()
+    )
+
+
+async def test_icon_object(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_object(index, "TestObject")
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/object.svg").pixmap(20, 20).toImage()
+    )
+
+
+async def test_icon_object_type(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_object_type(index, "TestObjectType")
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/object_type.svg").pixmap(20, 20).toImage()
+    )
+
+
+async def test_icon_property(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_property(index, "TestProperty", 42)
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/property.svg").pixmap(20, 20).toImage()
+    )
+
+
+async def test_icon_variable(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_variable(index, "TestVariable", 42)
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/variable.svg").pixmap(20, 20).toImage()
+    )
+
+
+async def test_icon_variable_type(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_variable_type(
+        index, "TestVariableType", 1
+    )
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/variable_type.svg").pixmap(20, 20).toImage()
+    )
+
+
+async def test_icon_method(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_method(
+        ua.NodeId("TestMethod", index),
+        ua.QualifiedName("TestMethod", index),
+        opc_method,
+        [ua.VariantType.Int64],
+        [ua.VariantType.Int64],
+    )
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/method.svg").pixmap(20, 20).toImage()
+    )
+
+
+async def test_icon_data_type(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_data_type(index, "TestDataType")
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/data_type.svg").pixmap(20, 20).toImage()
+    )
+
+
+async def test_icon_reference_type(mock_model, async_server):
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_reference_type(
+        index, "TestReferenceType"
+    )
+    item = OpcTreeItem(
+        mock_model, node, QPersistentModelIndex(), [ua.AttributeIds.DisplayName]
+    )
+    await item._refresh_data()
+
+    assert (
+        item.icon().pixmap(20, 20).toImage()
+        == QIcon(":/reference_type.svg").pixmap(20, 20).toImage()
+    )

--- a/uaclient/tree_ui/__init__.py
+++ b/uaclient/tree_ui/__init__.py
@@ -1,0 +1,1 @@
+from ._opc_tree_item import OpcTreeItem  # noqa: F401

--- a/uaclient/tree_ui/_opc_tree_item.py
+++ b/uaclient/tree_ui/_opc_tree_item.py
@@ -1,0 +1,231 @@
+import asyncio
+import copy
+from typing import Optional, Any, List, Dict, cast
+
+from PyQt5.QtCore import (
+    QObject,
+    pyqtSignal,
+    QPersistentModelIndex,
+    QModelIndex,
+    QAbstractItemModel,
+)
+from PyQt5.QtGui import QIcon
+
+from asyncua import ua, Node
+
+
+async def _refresh_item(item):
+    await item._refresh_data()
+    return item
+
+
+class OpcTreeItem(QObject):
+    data_changed = pyqtSignal(QModelIndex, QModelIndex)
+    item_added = pyqtSignal(QObject)
+    item_removed = pyqtSignal(QObject)
+
+    def __init__(
+        self,
+        model: QAbstractItemModel,
+        node: Node,
+        parent_index: QPersistentModelIndex,
+        columns: List[ua.AttributeIds],
+        *,
+        parent: Optional["OpcTreeItem"] = None,
+    ):
+        super().__init__(parent)
+        self.node = node
+        self._model = model
+        self._parent_index = parent_index
+        self._children: List["OpcTreeItem"] = []
+
+        self._display_name = ""
+        self._value = None
+        self._children_fetched = False
+        self._type_definition = None
+
+        self._requested_columns = columns
+        self._model_column_to_ua_column = dict(
+            [(index, column) for index, column in enumerate(columns)]
+        )
+        self._ua_column_to_model_column = dict(
+            [(column, index) for index, column in enumerate(columns)]
+        )
+
+        self._columns = copy.deepcopy(columns)
+
+        # We always need the node class to determine icon, even if it wasn't requested
+        if ua.AttributeIds.NodeClass not in self._columns:
+            self._columns.append(ua.AttributeIds.NodeClass)
+
+        # We always need the browse name for sorting, even if it wasn't requested
+        if ua.AttributeIds.BrowseName not in self._columns:
+            self._columns.append(ua.AttributeIds.BrowseName)
+
+        self._data: Dict[ua.AttributeIds, Any] = {}
+
+    async def _refresh_data(self) -> None:
+        self._type_definition = await self.node.read_type_definition()
+
+        values = await self.node.read_attributes(self._columns)
+        for index, column in enumerate(self._columns):
+            self.set_data(column, values[index].Value, emit=False)
+
+    async def refresh_children(self) -> None:
+        self.clear_children()  # Clear first
+
+        children = await self.node.get_children()
+        index = self.persistent_index(0)
+        items = [
+            OpcTreeItem(self._model, child, index, self._requested_columns)
+            for child in children
+        ]
+
+        self._model.beginInsertRows(QModelIndex(index), 0, len(children) - 1)
+
+        for task in asyncio.as_completed([_refresh_item(item) for item in items]):
+            item = await task
+            await self.add_child(item)
+
+        self._model.endInsertRows()
+
+        self._children_fetched = True
+
+    def set_parent_index(self, index: QPersistentModelIndex) -> None:
+        self._parent_index = index
+
+    def children_fetched(self) -> bool:
+        return self._children_fetched
+
+    async def add_child(self, child: "OpcTreeItem") -> None:
+        child.setParent(self)
+        child.set_parent_index(self.persistent_index(0))
+        child.data_changed.connect(self.data_changed)
+        child.item_added.connect(self.item_added)
+        child.item_removed.connect(self.item_removed)
+
+        try:
+            browse_name = child._data[ua.AttributeIds.BrowseName]
+        except KeyError:
+            await child._refresh_data()
+            browse_name = child._data[ua.AttributeIds.BrowseName]
+
+        # Maintain a sorted list here as we insert, so we don't have
+        # to sort after the fact. Using a sorted container would be
+        # more efficient, but it would be less clear and we really
+        # aren't dealing with that many nodes here.
+        destination_index = 0
+        for index, sibling in enumerate(self._children):
+            if browse_name < sibling._data[ua.AttributeIds.BrowseName]:
+                break
+            destination_index = index + 1
+
+        self._children.insert(destination_index, child)
+        self.item_added.emit(child)
+
+    def child(self, row: int) -> Optional["OpcTreeItem"]:
+        return self._children[row]
+
+    def persistent_index(self, column) -> QPersistentModelIndex:
+        if not self._parent_index.isValid():
+            # This must be the root item
+            return QPersistentModelIndex(self._model.index(0, 0))
+
+        return QPersistentModelIndex(
+            self._model.index(self.row(), column, QModelIndex(self._parent_index))
+        )
+
+    def clear_children(self, *, recursive=False) -> None:
+        self._children_fetched = False
+        children_count = self.child_count()
+        if children_count == 0:
+            return
+
+        if recursive:
+            for child in self._children:
+                child.clear_children(recursive=True)
+
+        index = QModelIndex(self.persistent_index(0))
+        self._model.beginRemoveRows(index, 0, children_count - 1)
+
+        for child in self._children:
+            self.item_removed.emit(child)
+
+        self._children.clear()
+
+        self._model.endRemoveRows()
+
+    def row(self) -> int:
+        parent = cast("OpcTreeItem", self.parent())
+
+        if parent is None:
+            return 0
+
+        return parent._children.index(self)
+
+    def child_count(self) -> int:
+        return len(self._children)
+
+    def column_count(self) -> int:
+        return len(self._requested_columns)
+
+    def data(self, column: int) -> Any:
+        return self._data[self._model_column_to_ua_column[column]]
+
+    def icon(self) -> Optional[QIcon]:
+        try:
+            node_class = self._data[ua.AttributeIds.NodeClass]
+        except KeyError:
+            return None
+
+        if node_class == ua.NodeClass.Object:
+            if self._type_definition is None:
+                return None
+
+            if self._type_definition == ua.TwoByteNodeId(ua.ObjectIds.FolderType):
+                return QIcon(":/folder.svg")
+            else:
+                return QIcon(":/object.svg")
+        elif node_class == ua.NodeClass.Variable:
+            if self._type_definition is None:
+                return None
+
+            if self._type_definition == ua.TwoByteNodeId(ua.ObjectIds.PropertyType):
+                return QIcon(":/property.svg")
+            else:
+                return QIcon(":/variable.svg")
+        elif node_class == ua.NodeClass.Method:
+            return QIcon(":/method.svg")
+        elif node_class == ua.NodeClass.ObjectType:
+            return QIcon(":/object_type.svg")
+        elif node_class == ua.NodeClass.VariableType:
+            return QIcon(":/variable_type.svg")
+        elif node_class == ua.NodeClass.DataType:
+            return QIcon(":/data_type.svg")
+        elif node_class == ua.NodeClass.ReferenceType:
+            return QIcon(":/reference_type.svg")
+
+        return None
+
+    def set_data(
+        self, attribute: ua.AttributeIds, value: ua.DataValue, *, emit: bool = True
+    ) -> None:
+        real_value = value.Value
+        if isinstance(real_value, ua.LocalizedText):
+            real_value = real_value.Text
+        elif isinstance(real_value, ua.Variant):
+            real_value = real_value.Value
+
+        self._data[attribute] = real_value
+
+        if emit:
+            # Emit signal letting subscribers know what data has changed here
+            index = QModelIndex(
+                self.persistent_index(self._ua_column_to_model_column[attribute])
+            )
+            self.data_changed.emit(index, index)
+
+    def __eq__(self, other) -> bool:
+        if isinstance(other, OpcTreeItem):
+            return self.node == other.node
+        return False


### PR DESCRIPTION
Working toward adding a QAbstractItemModel that uses the async API of asyncua. Each node in the model will be represented by a single `OpcTreeItem`. Each `OpcTreeItem` is part of a tree, and thus has an optional parent as well as children.

You can see how this item is used in #18.