### PR TITLE
tree_ui: add OpcTreeModel

### DIFF
--- a/tests/unit/tree_ui/test_opc_tree_model.py
+++ b/tests/unit/tree_ui/test_opc_tree_model.py
@@ -1,0 +1,193 @@
+import pytest
+
+from unittest import mock
+
+from PyQt5.QtCore import Qt, QModelIndex
+from PyQt5.QtWidgets import QTreeView
+from PyQt5.QtGui import QIcon
+
+from asyncua import ua
+
+from uaclient.tree_ui import OpcTreeModel
+
+
+@pytest.fixture
+def tree_view(qtbot):
+    view = QTreeView()
+    qtbot.addWidget(view)
+    yield view
+
+
+def test_init(tree_view):
+    with mock.patch.object(tree_view, "setModel") as mock_set_model:
+        model = OpcTreeModel(tree_view, [])
+
+    mock_set_model.assert_called_with(model)
+    assert model.columnCount() == 0
+    assert model.rowCount() == 0
+
+
+def test_init_columns(tree_view):
+    model = OpcTreeModel(
+        tree_view, [ua.AttributeIds.DisplayName, ua.AttributeIds.BrowseName]
+    )
+    assert model.columnCount() == 2
+    assert model.rowCount() == 0
+
+
+async def test_index(tree_view, async_server):
+    model = OpcTreeModel(tree_view, [ua.AttributeIds.DisplayName])
+
+    assert not model.index(0, 0).isValid()
+
+    index = await async_server.register_namespace("test")
+    object_node = await async_server.nodes.objects.add_object(index, "TestObject")
+    await model.set_root_node(object_node)
+
+    index = model.index(0, 0)
+    assert index.isValid()
+    assert index.data() == "TestObject"
+
+
+def test_header_data(tree_view):
+    model = OpcTreeModel(
+        tree_view, [ua.AttributeIds.DisplayName, ua.AttributeIds.BrowseName]
+    )
+
+    assert model.headerData(0, Qt.Orientation.Horizontal) == "Display Name"
+    assert model.headerData(1, Qt.Orientation.Horizontal) == "Browse Name"
+
+
+def test_header_data_all_possible_columns(tree_view):
+    model = OpcTreeModel(tree_view, [id for id in ua.AttributeIds])
+
+    assert model.columnCount() > 0
+
+    # Make sure no possible column throws KeyErrors when we're fetching its name
+    for column in range(model.columnCount()):
+        model.headerData(column, Qt.Orientation.Horizontal)
+
+
+async def test_data(tree_view, async_server, wait_for_signal):
+    model = OpcTreeModel(
+        tree_view, [ua.AttributeIds.DisplayName, ua.AttributeIds.Value]
+    )
+
+    index = await async_server.register_namespace("test")
+    object_node = await async_server.nodes.objects.add_object(index, "TestObject")
+    node = await object_node.add_variable(index, "TestVariable", 42)
+
+    await model.set_root_node(object_node)
+
+    root_index = model.index(0, 0)
+    tree_view.expanded.emit(root_index)
+    await wait_for_signal(
+        model.item_added, check_params_callback=lambda item: item.node == node
+    )
+
+    assert model.data(root_index) == "TestObject"
+    assert model.data(model.index(0, 0, root_index)) == "TestVariable"
+    assert model.data(model.index(0, 1, root_index)) == 42
+
+    # DecorationRole gets an icon
+    assert isinstance(
+        model.data(model.index(0, 0, root_index), Qt.ItemDataRole.DecorationRole), QIcon
+    )
+
+
+async def _expand_root_node(tree_view, async_server, wait_for_signal):
+    model = OpcTreeModel(tree_view, [ua.AttributeIds.Value])
+
+    index = await async_server.register_namespace("test")
+    object_node = await async_server.nodes.objects.add_object(index, "TestObject")
+    node = await object_node.add_variable(index, "TestVariable", 42)
+
+    await model.set_root_node(object_node)
+    assert model.rowCount() == 1
+
+    index = model.index(0, 0)
+    assert model.rowCount(index) == 0
+
+    tree_view.expanded.emit(index)
+    await wait_for_signal(
+        model.item_added, check_params_callback=lambda item: item.node == node
+    )
+
+    assert model.rowCount(index) == 1
+
+    return model, node
+
+
+async def test_expand_root_node(tree_view, async_server, wait_for_signal):
+    await _expand_root_node(tree_view, async_server, wait_for_signal)
+
+
+async def test_collapse_root_node(tree_view, async_server, wait_for_signal):
+    model, node = await _expand_root_node(tree_view, async_server, wait_for_signal)
+
+    index = model.index(0, 0)
+    assert model.rowCount(index) == 1
+
+    tree_view.collapsed.emit(index)
+    await wait_for_signal(
+        model.item_removed, check_params_callback=lambda item: item.node == node
+    )
+
+    assert model.rowCount(index) == 0
+
+
+async def test_data_changed(tree_view, async_server, wait_for_signal):
+    model, _node = await _expand_root_node(tree_view, async_server, wait_for_signal)
+
+    child_index = model.index(0, 0, model.index(0, 0))
+    assert child_index.isValid()
+
+    item = child_index.internalPointer()
+    item.set_data(ua.AttributeIds.Value, ua.DataValue(43))
+
+    data_index = QModelIndex(child_index)
+
+    def _check_params_callback(*args):
+        return args[0] == data_index and args[1] == data_index
+
+    await wait_for_signal(
+        model.dataChanged,
+        check_params_callback=_check_params_callback,
+    )
+
+
+async def test_has_children(tree_view, async_server, wait_for_signal):
+    model = OpcTreeModel(tree_view, [ua.AttributeIds.Value])
+
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_object(index, "TestObject")
+    await node.add_variable(index, "TestVariable", 42)
+
+    await model.set_root_node(node)
+    index = model.index(0, 0)
+
+    # We haven't actually fetched any yet, so it should assume we have children
+    assert model.hasChildren(index)
+
+    await index.internalPointer().refresh_children()
+
+    # Now we've fetched them, it knows we do
+    assert model.hasChildren(index)
+
+
+async def test_has_children_no_children(tree_view, async_server, wait_for_signal):
+    model = OpcTreeModel(tree_view, [ua.AttributeIds.Value])
+
+    index = await async_server.register_namespace("test")
+    node = await async_server.nodes.objects.add_variable(index, "TestVariable", 42)
+
+    await model.set_root_node(node)
+    index = model.index(0, 0)
+
+    # We haven't actually fetched any yet, so it should assume we have children
+    assert model.hasChildren(index)
+
+    await index.internalPointer().refresh_children()
+
+    # Now we've fetched them, it knows we do not
+    assert not model.hasChildren(index)

--- a/uaclient/tree_ui/__init__.py
+++ b/uaclient/tree_ui/__init__.py
@@ -1,1 +1,2 @@
 from ._opc_tree_item import OpcTreeItem  # noqa: F401
+from ._opc_tree_model import OpcTreeModel  # noqa: F401

--- a/uaclient/tree_ui/_opc_tree_model.py
+++ b/uaclient/tree_ui/_opc_tree_model.py
@@ -1,0 +1,184 @@
+from typing import Any, List, Union, Optional, overload
+
+from qasync import asyncSlot
+from PyQt5.QtCore import (
+    Qt,
+    QModelIndex,
+    QPersistentModelIndex,
+    pyqtSignal,
+    QAbstractItemModel,
+    QVariant,
+    QObject,
+)
+from PyQt5.QtWidgets import QTreeView
+
+from asyncua import Node
+from asyncua.ua import AttributeIds
+from ._opc_tree_item import OpcTreeItem
+
+_UA_ATTRIBUTE_NAMES = {
+    AttributeIds.NodeId: "Node ID",
+    AttributeIds.NodeClass: "Node Class",
+    AttributeIds.BrowseName: "Browse Name",
+    AttributeIds.DisplayName: "Display Name",
+    AttributeIds.Description: "Description",
+    AttributeIds.WriteMask: "Write Mask",
+    AttributeIds.UserWriteMask: "User Write Mask",
+    AttributeIds.IsAbstract: "Is Abstract",
+    AttributeIds.Symmetric: "Symmetric",
+    AttributeIds.InverseName: "Inverse Name",
+    AttributeIds.ContainsNoLoops: "Contains No Loops",
+    AttributeIds.EventNotifier: "Event Notifier",
+    AttributeIds.Value: "Value",
+    AttributeIds.DataType: "Data Type",
+    AttributeIds.ValueRank: "Value Rank",
+    AttributeIds.ArrayDimensions: "Array Dimensions",
+    AttributeIds.AccessLevel: "Access Level",
+    AttributeIds.UserAccessLevel: "User Access Level",
+    AttributeIds.MinimumSamplingInterval: "Minimum Sampling Interval",
+    AttributeIds.Historizing: "Historizing",
+    AttributeIds.Executable: "Executable",
+    AttributeIds.UserExecutable: "User Executable",
+    AttributeIds.DataTypeDefinition: "Data Type Definition",
+    AttributeIds.RolePermissions: "Role Permissions",
+    AttributeIds.UserRolePermissions: "User Role Permissions",
+    AttributeIds.AccessRestrictions: "Access Restrictions",
+    AttributeIds.AccessLevelEx: "Access Level",
+}
+
+
+class OpcTreeModel(QAbstractItemModel):
+    item_added = pyqtSignal(OpcTreeItem)
+    item_removed = pyqtSignal(OpcTreeItem)
+
+    def __init__(self, view: QTreeView, columns: List[AttributeIds]):
+        super().__init__()
+        self._columns = columns
+        self._root_item = OpcTreeItem(self, None, QPersistentModelIndex(), columns)
+        self._root_item.data_changed.connect(self._handle_data_changed)
+        self._root_item.item_added.connect(self.item_added)
+        self._root_item.item_removed.connect(self.item_removed)
+
+        view.setModel(self)
+        view.expanded.connect(self._handle_expanded)
+        view.collapsed.connect(self._handle_collapsed)
+
+    def index(
+        self, row: int, column: int, parent: QModelIndex = QModelIndex()
+    ) -> QModelIndex:
+        if not self.hasIndex(row, column, parent):
+            return QModelIndex()
+
+        parent_item = parent.internalPointer() if parent.isValid() else self._root_item
+        child_item = parent_item.child(row)
+        if child_item is None:
+            return QModelIndex()
+
+        return self.createIndex(row, column, child_item)
+
+    @overload
+    def parent(self, child: QModelIndex) -> QModelIndex: ...
+
+    @overload
+    def parent(self) -> Optional[QObject]: ...
+
+    def parent(
+        self, child: Optional[QModelIndex] = None
+    ) -> Union[Optional[QObject], QModelIndex]:
+        if child is None:
+            return super().parent()
+
+        if not child.isValid():
+            return QModelIndex()
+
+        child_item = child.internalPointer()
+        parent_item = child_item.parent()
+
+        if parent_item is None or parent_item == self._root_item:
+            return QModelIndex()
+
+        return self.createIndex(parent_item.row(), 0, parent_item)
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        if parent.column() > 0:
+            return 0
+
+        parent_item = parent.internalPointer() if parent.isValid() else self._root_item
+        if parent_item is None:
+            return 0
+
+        return parent_item.child_count()
+
+    def columnCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        parent_item = parent.internalPointer() if parent.isValid() else self._root_item
+        if parent_item is None:
+            return 0
+
+        return parent_item.column_count()
+
+    def data(self, index: QModelIndex, role: int = Qt.ItemDataRole.DisplayRole) -> Any:
+        if not index.isValid():
+            return None
+
+        item = index.internalPointer()
+        if role == Qt.ItemDataRole.DisplayRole:
+            return item.data(index.column())
+
+        if role == Qt.ItemDataRole.DecorationRole and index.column() == 0:
+            return item.icon()
+
+    async def set_root_node(self, node: Node):
+        index = self.index(0, 0)
+        item = OpcTreeItem(self, node, QPersistentModelIndex(), self._columns)
+
+        self.beginInsertRows(index, 0, 0)
+        await self._root_item.add_child(item)
+        self.endInsertRows()
+
+    def hasChildren(self, parent: QModelIndex = QModelIndex()) -> bool:
+        item = parent.internalPointer()
+
+        if not parent.isValid() or item.children_fetched():
+            return super().hasChildren(parent)
+
+        return True
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int = Qt.ItemDataRole.DisplayRole,
+    ) -> QVariant:
+        if (
+            role == Qt.ItemDataRole.DisplayRole
+            and orientation == Qt.Orientation.Horizontal
+        ):
+            return QVariant(_UA_ATTRIBUTE_NAMES[self._columns[section]])
+        return QVariant()
+
+    def clear(self) -> None:
+        self._root_item.clear_children(recursive=True)
+
+    @asyncSlot(QModelIndex, QModelIndex)
+    async def _handle_data_changed(
+        self, start_index: QModelIndex, end_index: QModelIndex
+    ) -> None:
+        self.dataChanged.emit(start_index, end_index)
+
+    @asyncSlot(QModelIndex)
+    async def _handle_expanded(self, index: QModelIndex) -> None:
+        if not index.isValid():
+            return
+
+        # Refresh the children for the item that was just expanded
+        item = index.internalPointer()
+        await item.refresh_children()
+
+    @asyncSlot(QModelIndex)
+    async def _handle_collapsed(self, index: QModelIndex) -> None:
+        if not index.isValid():
+            return
+
+        # Clear the children for the item just collapsed
+        item = index.internalPointer()
+        item.clear_children()


### PR DESCRIPTION
This is a `QAbstractItemModel` to be used in the main `QTreeView` that uses the async API of asyncua. It represents the OPC structure using a tree of `OpcTreeItem`s. The columns are selectable via its constructor.