### PR TITLE
fix app crashing on expanding large nodes

### DIFF
--- a/uaclient/tree_ui/_opc_tree_item.py
+++ b/uaclient/tree_ui/_opc_tree_item.py
@@ -229,9 +229,12 @@ class OpcTreeItem(QObject):
 
         if emit:
             # Emit signal letting subscribers know what data has changed here
-            index = QModelIndex(
-                self.persistent_index(self._ua_column_to_model_column[attribute])
-            )
+            column = self._ua_column_to_model_column[attribute]
+            try:
+                persistent_index = self.persistent_index(column)
+            except ValueError:
+                return
+            index = QModelIndex(persistent_index)
             self.data_changed.emit(index, index)
 
     def __eq__(self, other) -> bool:


### PR DESCRIPTION
This fixes a race condition that can happen if we are tying to subscribe/unsubscribe and something interrupts that. This would happen on occasion when expanding/collapsing large nodes. We can just suppress the error that gets thrown, otherwise the app will crash.