### PR TITLE
add expand/collapse all under a node

### DIFF
--- a/tests/unit/tree_ui/test_opc_tree_model.py
+++ b/tests/unit/tree_ui/test_opc_tree_model.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 from PyQt5.QtCore import Qt, QModelIndex
 from PyQt5.QtGui import QIcon
-
+from PyQt5.QtWidgets import QWidget
 from asyncua import ua
 
 from uaclient.tree_ui import OpcTreeModel
@@ -13,7 +13,8 @@ from uaclient.tree_ui import OPCTreeView
 
 @pytest.fixture
 def tree_view(application):
-    view = OPCTreeView()
+    parent = QWidget()
+    view = OPCTreeView(parent)
     yield view
     view.deleteLater()
 

--- a/tests/unit/tree_ui/test_opc_tree_model.py
+++ b/tests/unit/tree_ui/test_opc_tree_model.py
@@ -3,17 +3,17 @@ import pytest
 from unittest import mock
 
 from PyQt5.QtCore import Qt, QModelIndex
-from PyQt5.QtWidgets import QTreeView
 from PyQt5.QtGui import QIcon
 
 from asyncua import ua
 
 from uaclient.tree_ui import OpcTreeModel
+from uaclient.tree_ui import OPCTreeView
 
 
 @pytest.fixture
 def tree_view(application):
-    view = QTreeView()
+    view = OPCTreeView()
     yield view
     view.deleteLater()
 

--- a/uaclient/mainwindow_ui.py
+++ b/uaclient/mainwindow_ui.py
@@ -32,7 +32,7 @@ class Ui_MainWindow(object):
         self.splitter.setSizePolicy(sizePolicy)
         self.splitter.setOrientation(QtCore.Qt.Horizontal)
         self.splitter.setObjectName("splitter")
-        self.treeView = QtWidgets.QTreeView(self.splitter)
+        self.treeView = OPCTreeView(self.splitter)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Expanding)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -232,3 +232,14 @@ class Ui_MainWindow(object):
         self.actionDark_Mode.setText(_translate("MainWindow", "Dark Mode"))
         self.actionDark_Mode.setStatusTip(_translate("MainWindow", "Enables Dark Mode Theme"))
         self.actionClient_Application_Certificate.setText(_translate("MainWindow", "Client Application Certificate"))
+from uaclient.tree_ui._opc_tree_view import OPCTreeView
+
+
+if __name__ == "__main__":
+    import sys
+    app = QtWidgets.QApplication(sys.argv)
+    MainWindow = QtWidgets.QMainWindow()
+    ui = Ui_MainWindow()
+    ui.setupUi(MainWindow)
+    MainWindow.show()
+    sys.exit(app.exec_())

--- a/uaclient/mainwindow_ui.ui
+++ b/uaclient/mainwindow_ui.ui
@@ -30,7 +30,7 @@
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
-      <widget class="QTreeView" name="treeView">
+      <widget class="OPCTreeView" name="treeView">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
          <horstretch>0</horstretch>
@@ -363,6 +363,13 @@
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+  <customwidgets>
+  <customwidget>
+   <class>OPCTreeView</class>
+   <extends>QTreeView</extends>
+   <header>uaclient/tree_ui/_opc_tree_view</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>addrComboBox</tabstop>
   <tabstop>connectOptionButton</tabstop>

--- a/uaclient/tree_ui/__init__.py
+++ b/uaclient/tree_ui/__init__.py
@@ -1,2 +1,3 @@
 from ._opc_tree_item import OpcTreeItem  # noqa: F401
 from ._opc_tree_model import OpcTreeModel  # noqa: F401
+from ._opc_tree_view import OPCTreeView  # noqa: F401

--- a/uaclient/tree_ui/_opc_tree_item.py
+++ b/uaclient/tree_ui/_opc_tree_item.py
@@ -44,7 +44,7 @@ class OpcTreeItem(QObject):
         self._value = None
         self._children_fetched = False
         self._type_definition = None
-
+    
         self._requested_columns = columns
         self._model_column_to_ua_column = dict(
             [(index, column) for index, column in enumerate(columns)]
@@ -54,6 +54,7 @@ class OpcTreeItem(QObject):
         )
 
         self._columns = copy.deepcopy(columns)
+        self.is_refreshing_children = False
 
         # We always need the node class to determine icon, even if it wasn't requested
         if ua.AttributeIds.NodeClass not in self._columns:
@@ -73,6 +74,7 @@ class OpcTreeItem(QObject):
             self.set_data(column, values[index].Value, emit=False)
 
     async def refresh_children(self) -> None:
+        self.is_refreshing_children = True
         self.clear_children()  # Clear first
 
         children = await self.node.get_children()
@@ -91,6 +93,7 @@ class OpcTreeItem(QObject):
         self._model.endInsertRows()
 
         self._children_fetched = True
+        self.is_refreshing_children = False
 
     def set_parent_index(self, index: QPersistentModelIndex) -> None:
         self._parent_index = index

--- a/uaclient/tree_ui/_opc_tree_item.py
+++ b/uaclient/tree_ui/_opc_tree_item.py
@@ -44,7 +44,7 @@ class OpcTreeItem(QObject):
         self._value = None
         self._children_fetched = False
         self._type_definition = None
-    
+
         self._requested_columns = columns
         self._model_column_to_ua_column = dict(
             [(index, column) for index, column in enumerate(columns)]

--- a/uaclient/tree_ui/_opc_tree_view.py
+++ b/uaclient/tree_ui/_opc_tree_view.py
@@ -1,0 +1,38 @@
+
+from PyQt5.QtWidgets import QTreeView
+# from uaclient.tree.expand_collapse_manager import ExpandCollapseManager
+from PyQt5.QtCore import pyqtSignal, Qt, QModelIndex
+
+from qasync import asyncSlot
+
+
+class OPCTreeView(QTreeView):
+    shift_click_expand = pyqtSignal(QModelIndex)
+    shift_click_collapse = pyqtSignal(QModelIndex)
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.hasShiftExpanded = False
+        self.hasShiftCollapsed = False
+        # self.expanded.connect(self.expandHandler)
+
+    # def expand(self, index: QModelIndex) -> None:
+    #     self.isIndexValid(index)
+    #     # if expanded:
+    #     #     self.expand(index, False)
+    #     # else:
+    #     #     self.collapse(index)
+    #     print('expanded')
+    def mousePressEvent(self, event):
+        idx = self.indexAt(event.pos())
+        if idx.isValid() and event.modifiers() & Qt.ShiftModifier:
+
+            if self.isExpanded(idx):
+
+                self.hasShiftCollapsed = True
+                self.shift_click_collapse.emit(idx)
+            else:
+                self.hasShiftExpanded = True
+                self.shift_click_expand.emit(idx)
+        else:
+            super().mousePressEvent(event)

--- a/uaclient/tree_ui/_opc_tree_view.py
+++ b/uaclient/tree_ui/_opc_tree_view.py
@@ -1,5 +1,5 @@
-
 from PyQt5.QtWidgets import QTreeView
+
 # from uaclient.tree.expand_collapse_manager import ExpandCollapseManager
 from PyQt5.QtCore import pyqtSignal, Qt, QModelIndex
 

--- a/uaclient/tree_ui/_opc_tree_view.py
+++ b/uaclient/tree_ui/_opc_tree_view.py
@@ -14,15 +14,7 @@ class OPCTreeView(QTreeView):
         super().__init__(parent)
         self.hasShiftExpanded = False
         self.hasShiftCollapsed = False
-        # self.expanded.connect(self.expandHandler)
 
-    # def expand(self, index: QModelIndex) -> None:
-    #     self.isIndexValid(index)
-    #     # if expanded:
-    #     #     self.expand(index, False)
-    #     # else:
-    #     #     self.collapse(index)
-    #     print('expanded')
     def mousePressEvent(self, event):
         idx = self.indexAt(event.pos())
         if idx.isValid() and event.modifiers() & Qt.ShiftModifier:


### PR DESCRIPTION
This feature adds the ability for a user to expand/collapse all of the nodes underneath it along with all of its nodes children, grandchildren, and so on until all of the children are expanded. It expands per generation, rather than expanding recursively.